### PR TITLE
Error handling when dll cannot be loaded

### DIFF
--- a/bin/oculus_touch.ahk
+++ b/bin/oculus_touch.ahk
@@ -74,6 +74,16 @@ Vibrate(controller, frequency, amplitude)
 
 ; Grab the library. 
 hModule := DllCall("LoadLibrary", "Str", "auto_oculus_touch.dll", "Ptr")
+if !hModule
+{
+    if (A_LastError = 193)
+    {
+        MsgBox You're trying to load 64-bit dll with 32-bit AutoHotkey, use AutoHotkeyU64.exe
+    } else {
+        MsgBox Failed to load dll (error %A_LastError%).
+    }
+    ExitApp
+}
 
 ; Start the Oculus sdk.
 DllCall("auto_oculus_touch\initOculus")


### PR DESCRIPTION
My AutoHotkey was set to run ahk files as 32-bit for some reason. The auto_oculus_touch.dll failed to load because of this (it seems to be 64-bit), but the script just kept happily running without any errors.

I added an error message to the script that alerts the user if the dll couldn't be loaded, and stops the script. I also added more descriptive error message to my particular problem.